### PR TITLE
feat: Add macOS check to cdefaults script

### DIFF
--- a/bin/cdefaults
+++ b/bin/cdefaults
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ "$(uname)" != 'Darwin' ]]; then
+  echo 'Warning: This script is intended for macOS only.' >&2
+  exit 0
+fi
+
 defaults write com.apple.dock autohide -bool true
 defaults write com.apple.dock magnification -bool false
 defaults write com.apple.dock orientation -string 'left'


### PR DESCRIPTION
Adds a check to the beginning of the `bin/cdefaults` script to ensure it only runs on macOS (Darwin).

If the script is executed on a non-macOS system, it will now print a warning to stderr and exit gracefully. This prevents errors when running dotfile setup on other operating systems like Ubuntu.