### PR TITLE
fix: Make owner flag variable name consistent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ create_symlink() {
 }
 
 is_owner() {
-  if "$as_owner"; then
+  if [[ "$as_owner" == true ]]; then
     return 0
   fi
   [[ "$(whoami)" == 'hairihou' ]]

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+as_owner=false
+for arg in "$@"; do
+  if [[ "$arg" == '--as-owner' ]]; then
+    as_owner=true
+    break
+  fi
+done
+
 readonly dst="$HOME/dotfiles"
 readonly src='https://github.com/hairihou/dotfiles.git'
 
@@ -18,6 +26,9 @@ create_symlink() {
 }
 
 is_owner() {
+  if "$as_owner"; then
+    return 0
+  fi
   [[ "$(whoami)" == 'hairihou' ]]
 }
 


### PR DESCRIPTION
Renames the internal variable from `force_owner` to `as_owner`.

This makes the variable name consistent with the `--as-owner` command-line flag, improving code readability and maintainability.